### PR TITLE
usage of urn:uuid causes validation issues

### DIFF
--- a/Standalone-Examples/eRezept(KBV)/1.1.0/special-cases/packagingsize-text.xml
+++ b/Standalone-Examples/eRezept(KBV)/1.1.0/special-cases/packagingsize-text.xml
@@ -11,7 +11,7 @@
 	<type value="document"/>
 	<timestamp value="2023-07-11T14:34:52Z"/>
 	<entry>
-		<fullUrl value="urn:uuid:48c4fa6c-ec99-4241-9af4-bfe76af2b652"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Composition/48c4fa6c-ec99-4241-9af4-bfe76af2b652"/>
 		<resource>
 			<Composition xmlns="http://hl7.org/fhir">
 				<id value="48c4fa6c-ec99-4241-9af4-bfe76af2b652"/>
@@ -32,11 +32,11 @@
 					</coding>
 				</type>
 				<subject>
-					<reference value="urn:uuid:e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
+					<reference value="Patient/e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
 				</subject>
 				<date value="2023-07-11"/>
 				<author>
-					<reference value="urn:uuid:604f930b-395d-4247-b901-6698ce29d6f0"/>
+					<reference value="Practitioner/604f930b-395d-4247-b901-6698ce29d6f0"/>
 					<type value="Practitioner"/>
 				</author>
 				<author>
@@ -48,7 +48,7 @@
 				</author>
 				<title value="elektronische Arzneimittelverordnung"/>
 				<custodian>
-					<reference value="urn:uuid:dd3e9a7d-1cf3-4b46-b43e-56e642f87f3a"/>
+					<reference value="Organization/dd3e9a7d-1cf3-4b46-b43e-56e642f87f3a"/>
 				</custodian>
 				<section>
 					<code>
@@ -58,7 +58,7 @@
 						</coding>
 					</code>
 					<entry>
-						<reference value="urn:uuid:c0312f32-4f6c-49b3-b3f4-21506785d583"/>
+						<reference value="MedicationRequest/c0312f32-4f6c-49b3-b3f4-21506785d583"/>
 					</entry>
 				</section>
 				<section>
@@ -69,14 +69,14 @@
 						</coding>
 					</code>
 					<entry>
-						<reference value="urn:uuid:a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
+						<reference value="Coverage/a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
 					</entry>
 				</section>
 			</Composition>
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:c0312f32-4f6c-49b3-b3f4-21506785d583"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/MedicationRequest/c0312f32-4f6c-49b3-b3f4-21506785d583"/>
 		<resource>
 			<MedicationRequest xmlns="http://hl7.org/fhir">
 				<id value="c0312f32-4f6c-49b3-b3f4-21506785d583"/>
@@ -103,17 +103,17 @@
 				<status value="active"/>
 				<intent value="order"/>
 				<medicationReference>
-					<reference value="urn:uuid:d26d162c-59b6-465d-a8e1-91b570461e8f"/>
+					<reference value="Medication/d26d162c-59b6-465d-a8e1-91b570461e8f"/>
 				</medicationReference>
 				<subject>
-					<reference value="urn:uuid:e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
+					<reference value="Patient/e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
 				</subject>
 				<authoredOn value="2023-07-11"/>
 				<requester>
-					<reference value="urn:uuid:604f930b-395d-4247-b901-6698ce29d6f0"/>
+					<reference value="Practitioner/604f930b-395d-4247-b901-6698ce29d6f0"/>
 				</requester>
 				<insurance>
-					<reference value="urn:uuid:a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
+					<reference value="Coverage/a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
 				</insurance>
 				<dosageInstruction>
 					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_DosageFlag">
@@ -135,7 +135,7 @@
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:d26d162c-59b6-465d-a8e1-91b570461e8f"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Medication/d26d162c-59b6-465d-a8e1-91b570461e8f"/>
 		<resource>
 			<Medication xmlns="http://hl7.org/fhir">
 				<id value="d26d162c-59b6-465d-a8e1-91b570461e8f"/>
@@ -192,7 +192,7 @@
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Patient/e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
 		<resource>
 			<Patient xmlns="http://hl7.org/fhir">
 				<id value="e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
@@ -237,7 +237,7 @@
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:604f930b-395d-4247-b901-6698ce29d6f0"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Practitioner/604f930b-395d-4247-b901-6698ce29d6f0"/>
 		<resource>
 			<Practitioner xmlns="http://hl7.org/fhir">
 				<id value="604f930b-395d-4247-b901-6698ce29d6f0"/>
@@ -295,7 +295,7 @@
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:dd3e9a7d-1cf3-4b46-b43e-56e642f87f3a"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Organization/dd3e9a7d-1cf3-4b46-b43e-56e642f87f3a"/>
 		<resource>
 			<Organization xmlns="http://hl7.org/fhir">
 				<id value="dd3e9a7d-1cf3-4b46-b43e-56e642f87f3a"/>
@@ -354,7 +354,7 @@
 		</resource>
 	</entry>
 	<entry>
-		<fullUrl value="urn:uuid:a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
+		<fullUrl value="http://pvs.praxis.local/fhir/Coverage/a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
 		<resource>
 			<Coverage xmlns="http://hl7.org/fhir">
 				<id value="a02eafd7-7ede-4ade-b518-bc7fbc1be414"/>
@@ -393,7 +393,7 @@
 					</coding>
 				</type>
 				<beneficiary>
-					<reference value="urn:uuid:e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
+					<reference value="Patient/e5cd146d-fcfd-4614-9b61-87ce84d71b47"/>
 				</beneficiary>
 				<payor>
 					<identifier>


### PR DESCRIPTION
usage of urn:uuid causes validation issue, that id would be missing (which is actually is not the case)

When using `http://pvs.praxis.local/fhir/<entityName>/<id>` in full URL and `<entityName>/<id>` in references (as done in all other examples), validation passes.

So not sure how the urn:uuid approach is expected to work.