### PR TITLE
Add the examples from the MedicationDispense objects generated for the Konnektathon 

### DIFF
--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/03-MedicationDispense.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/03-MedicationDispense.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MedicationDispense xmlns="http://hl7.org/fhir">
+  <id value="20ae2d0b-d1a9-4a9a-aeb6-580148f7da7e" />
+  <meta>
+    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2" />
+  </meta>
+  <contained>
+    <Medication>
+      <id value="2ef461fb-d4da-4b0d-a591-298ea3c6aec3" />
+      <meta>
+        <profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0" />
+      </meta>
+      <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+        <valueCoding>
+          <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category" />
+          <code value="00" />
+        </valueCoding>
+      </extension>
+      <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+        <valueBoolean value="false" />
+      </extension>
+      <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+        <valueCodeableConcept>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <version value="http://snomed.info/sct/900000000000207008/version/20220331" />
+            <code value="763158003" />
+            <display value="Medicinal product (product)" />
+          </coding>
+        </valueCodeableConcept>
+      </extension>
+      <extension url="http://fhir.de/StructureDefinition/normgroesse">
+        <valueCode value="N1" />
+      </extension>
+      <code>
+        <coding>
+          <system value="http://fhir.de/CodeSystem/ifa/pzn" />
+          <code value="10217060" />
+        </coding>
+        <text value="NEUPRO 8MG/24H            PFT      7ST / EMRA-MED" />
+      </code>
+      <form>
+        <coding>
+          <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM" />
+          <code value="PFT" />
+        </coding>
+      </form>
+      <amount>
+        <numerator>
+          <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+            <valueString value="7" />
+          </extension>
+          <unit value="Pflaster tra" />
+        </numerator>
+        <denominator>
+          <value value="1" />
+        </denominator>
+      </amount>
+    </Medication>
+  </contained>
+  <identifier>
+    <system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+    <value value="160.000.226.436.264.16" />
+  </identifier>
+  <status value="completed" />
+  <medicationReference>
+    <reference value="#2ef461fb-d4da-4b0d-a591-298ea3c6aec3" />
+    <display value="NEUPRO 8MG/24H            PFT      7ST / EMRA-MED" />
+  </medicationReference>
+  <subject>
+    <identifier>
+      <system value="http://fhir.de/sid/gkv/kvid-10" />
+      <value value="X110450929" />
+    </identifier>
+  </subject>
+  <performer>
+    <actor>
+      <identifier>
+        <system value="https://gematik.de/fhir/sid/telematik-id" />
+        <value value="3-abc-1234567890" />
+      </identifier>
+    </actor>
+  </performer>
+  <whenHandedOver value="2024-07-02" />
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.204.02_medicationdispense_Sumatriptan_PZN.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.204.02_medicationdispense_Sumatriptan_PZN.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="1c5db392-40ee-481b-987f-f4bfa389abdd">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="04866280">
+					</code>
+				</coding>
+				<text value="Sumatriptan Dura 100mg">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="FTA">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="12">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.204.02">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#1c5db392-40ee-481b-987f-f4bfa389abdd">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="Z828875733">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T09:29:09+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="1-0-1-0">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.206.93_medicationdispense_Neupro_PZN.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.206.93_medicationdispense_Neupro_PZN.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="2253116c-2a97-41ca-b7f9-6cda642982b7">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N1">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="18369912">
+					</code>
+				</coding>
+				<text value="Rotigotin Neurax 8mg/24H">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="PFT">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="7">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.206.93">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#2253116c-2a97-41ca-b7f9-6cda642982b7">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110474905">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T09:34:04+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="1 Pflaster am Tag">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.215.66_medicationdispense_3Prospan_PZN.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.215.66_medicationdispense_3Prospan_PZN.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="b8cd5418-6196-4284-b38e-1dda2cb18c34">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N1">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="08585997">
+					</code>
+				</coding>
+				<text value="Prospan Hustensaft">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="FLE">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="ml">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.215.66">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#b8cd5418-6196-4284-b38e-1dda2cb18c34">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="Z828875733">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T09:36:50+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="2mal tägl. 5ml">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.241.85_medicationdispense_6Viani_PZN.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.241.85_medicationdispense_6Viani_PZN.xml
@@ -1,0 +1,110 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="daec989b-a2bd-4398-bb23-98b011cf2ba4">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="16875114">
+					</code>
+				</coding>
+				<text value="Salmeterol/Flut AL50/250UG">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="IHP">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="180">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.241.85">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#daec989b-a2bd-4398-bb23-98b011cf2ba4">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="H064287850">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T09:51:11+02:00">
+	</whenHandedOver>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.373.77_medicationdispense_5Januvia_PZN.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.373.77_medicationdispense_5Januvia_PZN.xml
@@ -1,0 +1,110 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="ebdf3d02-f586-4f51-b40d-93604d23d7d0">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="17974137">
+					</code>
+				</coding>
+				<text value="Sitagliptin Glenmark 50mg">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="FTA">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="98">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.373.77">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#ebdf3d02-f586-4f51-b40d-93604d23d7d0">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="Z828875733">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:30:42+02:00">
+	</whenHandedOver>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.549.34_medicationdispense_Rezeptur.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.549.34_medicationdispense_Rezeptur.xml
@@ -1,0 +1,128 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="be05e244-a57b-4a64-9f4a-db8b1becba5b">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_Compounding|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="373873005:860781008=362943005">
+						</code>
+						<display value="Pharmaceutical / biologic product (product) : Has product characteristic (attribute) = Manual method (qualifier value)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<code>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type">
+					</system>
+					<code value="rezeptur">
+					</code>
+				</coding>
+			</code>
+			<form>
+				<text value="Lösung">
+				</text>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="ml">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+			<ingredient>
+				<itemCodeableConcept>
+					<text value="Salicylsäure">
+					</text>
+				</itemCodeableConcept>
+				<strength>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Ingredient_Amount">
+						<valueString value="5g">
+						</valueString>
+					</extension>
+				</strength>
+			</ingredient>
+			<ingredient>
+				<itemCodeableConcept>
+					<text value="2-propanol 70 %">
+					</text>
+				</itemCodeableConcept>
+				<strength>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Ingredient_Amount">
+						<valueString value="Ad 100 g">
+						</valueString>
+					</extension>
+				</strength>
+			</ingredient>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.549.34">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#be05e244-a57b-4a64-9f4a-db8b1becba5b">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="Z828875733">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:01:36+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="1–3mal/Tag auf die erkrankten Hautstellen auftragen">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.564.86_medicationdispense_MVO.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.564.86_medicationdispense_MVO.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="77f07338-e96f-4b86-a485-55f86967d8a0">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="02532741">
+					</code>
+				</coding>
+				<text value="L Thyroxin 75 Henning">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.564.86">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#77f07338-e96f-4b86-a485-55f86967d8a0">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110474905">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:15:00+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="Dj">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.593.96_medicationdispense_Wirkstoff_mit_Austausch.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.593.96_medicationdispense_Wirkstoff_mit_Austausch.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="aba84b3f-b1fc-4a3a-bab4-9cc46f24783f">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="00476441">
+					</code>
+				</coding>
+				<text value="Lisinopril 10 Heumann">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.593.96">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#aba84b3f-b1fc-4a3a-bab4-9cc46f24783f">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="Z828875733">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:22:37+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="1-0-0-0">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.627.91_medicationdispense_WST.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.627.91_medicationdispense_WST.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="05317d83-14f7-4b7b-9bba-6fcfdeea3f57">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="00766759">
+					</code>
+				</coding>
+				<text value="Ramipril 1A Pharma 5 mg">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.627.91">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#05317d83-14f7-4b7b-9bba-6fcfdeea3f57">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110450929">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:18:44+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="1-0-0-0">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.697.75_medicationdispense_Ramipril_WST_2x50+5x20_Abgabe.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.697.75_medicationdispense_Ramipril_WST_2x50+5x20_Abgabe.xml
@@ -1,0 +1,110 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="bddd9a9c-2171-4dbc-8d05-66bb619ed849">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N1">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="01983625">
+					</code>
+				</coding>
+				<text value="Ramilich 5mg Tabletten">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="20">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.697.75">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#bddd9a9c-2171-4dbc-8d05-66bb619ed849">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110474905">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T12:01:22+02:00">
+	</whenHandedOver>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.713.27_medicationdispense_Venlafaxin_PZN_kleinePackungen.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.713.27_medicationdispense_Venlafaxin_PZN_kleinePackungen.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="a62bb615-2179-4eb4-bcfa-e0ccac2f1feb">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="09494280">
+					</code>
+				</coding>
+				<text value="Venlafaxin HEU 75mg Tabl">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.713.27">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#a62bb615-2179-4eb4-bcfa-e0ccac2f1feb">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110450929">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:36:22+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="Dj">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.714.24_medicationdispense_Venlafaxin_PZN_Austausch.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.714.24_medicationdispense_Venlafaxin_PZN_Austausch.xml
@@ -1,0 +1,114 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="3d77aba2-06de-4865-ba9c-df62af829aa8">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N3">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="03480822">
+					</code>
+				</coding>
+				<text value="Tramadol 100 RET 1A Pharma">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="RET">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="100">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.714.24">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#3d77aba2-06de-4865-ba9c-df62af829aa8">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="H064287850">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:46:33+02:00">
+	</whenHandedOver>
+	<dosageInstruction>
+		<text value="Dj">
+		</text>
+	</dosageInstruction>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.776.32_medicationdispense_Venlafaxin_PZN_kleinePackungen.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/160.000.226.436.776.32_medicationdispense_Venlafaxin_PZN_kleinePackungen.xml
@@ -1,0 +1,110 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2">
+		</profile>
+	</meta>
+	<contained>
+		<Medication>
+			<id value="87f5bbd5-24a1-4e2d-b9d1-afe3957c0e10">
+			</id>
+			<meta>
+				<profile value="https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0">
+				</profile>
+			</meta>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+				<valueCoding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category">
+					</system>
+					<code value="00">
+					</code>
+				</valueCoding>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+				<valueCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct">
+						</system>
+						<version value="http://snomed.info/sct/900000000000207008/version/20220331">
+						</version>
+						<code value="763158003">
+						</code>
+						<display value="Medicinal product (product)">
+						</display>
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+			<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+				<valueBoolean value="false">
+				</valueBoolean>
+			</extension>
+			<extension url="http://fhir.de/StructureDefinition/normgroesse">
+				<valueCode value="N2">
+				</valueCode>
+			</extension>
+			<code>
+				<coding>
+					<system value="http://fhir.de/CodeSystem/ifa/pzn">
+					</system>
+					<code value="05392022">
+					</code>
+				</coding>
+				<text value="Venlafaxin 1A Pharma 75mg">
+				</text>
+			</code>
+			<form>
+				<coding>
+					<system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM">
+					</system>
+					<code value="TAB">
+					</code>
+				</coding>
+			</form>
+			<amount>
+				<numerator>
+					<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+						<valueString value="50">
+						</valueString>
+					</extension>
+					<unit value="St">
+					</unit>
+				</numerator>
+				<denominator>
+					<value value="1">
+					</value>
+				</denominator>
+			</amount>
+		</Medication>
+	</contained>
+	<identifier>
+		<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId">
+		</system>
+		<value value="160.000.226.436.776.32">
+		</value>
+	</identifier>
+	<status value="completed">
+	</status>
+	<medicationReference>
+		<reference value="#87f5bbd5-24a1-4e2d-b9d1-afe3957c0e10">
+		</reference>
+	</medicationReference>
+	<subject>
+		<identifier>
+			<system value="http://fhir.de/sid/gkv/kvid-10">
+			</system>
+			<value value="X110474905">
+			</value>
+		</identifier>
+	</subject>
+	<performer>
+		<actor>
+			<identifier>
+				<system value="https://gematik.de/fhir/sid/telematik-id">
+				</system>
+				<value value="3-abc-1234567890">
+				</value>
+			</identifier>
+		</actor>
+	</performer>
+	<whenHandedOver value="2024-07-02T11:55:14+02:00">
+	</whenHandedOver>
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/MedicationDispense-01.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/MedicationDispense-01.xml
@@ -1,0 +1,82 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+    <meta>
+        <profile value="[https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"|https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense%7C1.2%22] />
+    </meta>
+    <contained>
+        <Medication>
+            <id value="5cdcaacc-7068-4a1e-8fb7-939ccf136dfb" />
+            <meta>
+                <profile value="[https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0"|https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN%7C1.1.0%22] />
+            </meta>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+                <valueCoding>
+                    <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category" />
+                    <code value="00" />
+                </valueCoding>
+            </extension>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+                <valueCodeableConcept>
+                    <coding>
+                        <system value="http://snomed.info/sct" />
+                        <version value="http://snomed.info/sct/900000000000207008/version/20220331" />
+                        <code value="763158003" />
+                        <display value="Medicinal product (product)" />
+                    </coding>
+                </valueCodeableConcept>
+            </extension>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+                <valueBoolean value="false" />
+            </extension>
+            <extension url="http://fhir.de/StructureDefinition/normgroesse">
+                <valueCode value="N1" />
+            </extension>
+            <code>
+                <coding>
+                    <system value="http://fhir.de/CodeSystem/ifa/pzn" />
+                <code value="17599389" />
+                </coding>
+                <text value="SITAGLIPTIN ZEN 50MG FTA" />
+            </code>
+            <form>
+                <coding>
+                    <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM" />
+                    <code value="FTA" />
+                </coding>
+            </form>
+            <amount>
+                <numerator>
+                    <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+                        <valueString value="28" />
+                    </extension>
+                    <unit value="St" />
+                </numerator>
+                <denominator>
+                    <value value="1" />
+                </denominator>
+            </amount>
+        </Medication>
+    </contained>
+    <identifier>
+        <system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+        <value value="160.000.226.436.371.83" />
+    </identifier>
+    <status value="completed" />
+    <medicationReference>
+        <reference value="#5cdcaacc-7068-4a1e-8fb7-939ccf136dfb" />
+    </medicationReference>
+    <subject>
+        <identifier>
+            <system value="http://fhir.de/sid/gkv/kvid-10" />
+            <value value="H064287850" />
+        </identifier>
+    </subject>
+    <performer>
+        <actor>
+            <identifier>
+                <system value="https://gematik.de/fhir/sid/telematik-id" />
+                <value value="3-abc-1234567890" />
+            </identifier>
+        </actor>
+    </performer>
+    <whenHandedOver value="2024-07-02" />
+</MedicationDispense>

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/MedicationDispense-02.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.2.0/Konnektathon_MedicationDispense/MedicationDispense-02.xml
@@ -1,0 +1,85 @@
+<MedicationDispense xmlns="http://hl7.org/fhir">
+    <meta>
+        <profile value="[https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"|https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense%7C1.2%22] />
+    </meta>
+    <contained>
+        <Medication>
+            <id value="03d104ff-03d1-4bc3-953b-883d8b4fc5ea" />
+            <meta>
+                <profile value="[https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0"|https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN%7C1.1.0%22] />
+            </meta>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category">
+                <valueCoding>
+                    <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category" />
+                    <code value="00" />
+                </valueCoding>
+            </extension>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type">
+                <valueCodeableConcept>
+                    <coding>
+                        <system value="http://snomed.info/sct" />
+                        <version value="http://snomed.info/sct/900000000000207008/version/20220331" />
+                        <code value="763158003" />
+                        <display value="Medicinal product (product)" />
+                    </coding>
+                </valueCodeableConcept>
+            </extension>
+            <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine">
+                <valueBoolean value="false" />
+            </extension>
+            <extension url="http://fhir.de/StructureDefinition/normgroesse">
+                <valueCode value="N1" />
+            </extension>
+            <code>
+                <coding>
+                    <system value="http://fhir.de/CodeSystem/ifa/pzn" />
+                    <code value="08671219" />
+                </coding>
+                <text value="ACICLOVIR 800 1A PHARMA" />
+            </code>
+            <form>
+                <coding>
+                    <system value="https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM" />
+                    <code value="TAB" />
+                </coding>
+            </form>
+            <amount>
+                <numerator>
+                    <extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize">
+                        <valueString value="35" />
+                    </extension>
+                    <unit value="St" />
+                </numerator>
+                <denominator>
+                    <value value="1" />
+                </denominator>
+            </amount>
+        </Medication>
+    </contained>
+    <identifier>
+        <system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+        <value value="160.000.226.436.376.68" />
+    </identifier>
+    <status value="completed" />
+    <medicationReference>
+        <reference value="#03d104ff-03d1-4bc3-953b-883d8b4fc5ea" />
+    </medicationReference>
+    <subject>
+        <identifier>
+            <system value="http://fhir.de/sid/gkv/kvid-10" />
+            <value value="Z828875733" />
+        </identifier>
+    </subject>
+    <performer>
+        <actor>
+            <identifier>
+                <system value="https://gematik.de/fhir/sid/telematik-id" />
+                <value value="3-abc-1234567890" />
+            </identifier>
+        </actor>
+    </performer>
+    <whenHandedOver value="2024-07-02" />
+    <dosageInstruction>
+        <text value="Irgendeine Dosierinfo" />
+    </dosageInstruction>
+</MedicationDispense>


### PR DESCRIPTION
The following MedicationDispense examples were generated for the Konnektathon and are being added to the repo for future use