### PR TITLE
Update the ID values for the Communication API examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  REFERENZVALIDATOR_VERSION: 2.0.2
+  REFERENZVALIDATOR_VERSION: 2.5.0
   PATH_TO_EXAMPLES: './temp_folder/'
   FHIR_VERSION: "4.0"
   INPUT_JAVA_VALIDATION_OPTIONS: "-tx http://tx.fhir.org -debug -allow-example-urls true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -43,7 +43,7 @@ jobs:
       
       # Install Java runtime (only needed if you want to run the offical HL7 Java validator)
       - name: Setup Java JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'

--- a/API-Examples/2024-11-01/erp_communication/02_response_PostPatientToPharmacy.json
+++ b/API-Examples/2024-11-01/erp_communication/02_response_PostPatientToPharmacy.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Communication",
-  "id": "12345",
+  "id": "66f2fd42-773b-465c-bd2c-9fbefbd2e6f4",
   "meta": {
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",

--- a/API-Examples/2024-11-01/erp_communication/04_response_PostPharmacyToPatient.xml
+++ b/API-Examples/2024-11-01/erp_communication/04_response_PostPharmacyToPatient.xml
@@ -1,5 +1,5 @@
 <Communication xmlns="http://hl7.org/fhir">
-    <id value="12346"/>
+    <id value="8f9bb3ea-3480-45ea-bb0b-ffd33c57e4af"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-03-12T18:01:10+00:00"/>

--- a/API-Examples/2024-11-01/erp_communication/06_response_RezeptZuweisen.json
+++ b/API-Examples/2024-11-01/erp_communication/06_response_RezeptZuweisen.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Communication",
-  "id": "12350",
+  "id": "7101a5e5-4b54-4199-95f5-ffc505c8a33b",
   "meta": {
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",

--- a/API-Examples/2024-11-01/erp_communication/07_response_GetMessages.json
+++ b/API-Examples/2024-11-01/erp_communication/07_response_GetMessages.json
@@ -17,7 +17,7 @@
       "fullUrl": "https://erp.zentral.erp.splitdns.ti-dienste.de/Communication/12346",
       "resource": {
         "resourceType": "Communication",
-        "id": "12346",
+        "id": "8f9bb3ea-3480-45ea-bb0b-ffd33c57e4af",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2020-03-12T18:15:10+00:00",

--- a/API-Examples/2024-11-01/erp_communication/08_response_GetAllMessages.xml
+++ b/API-Examples/2024-11-01/erp_communication/08_response_GetAllMessages.xml
@@ -17,7 +17,7 @@
         <fullUrl value="https://erp.zentral.erp.splitdns.ti-dienste.de/Communication/74671"/>
         <resource>
             <Communication xmlns="http://hl7.org/fhir">
-                <id value="74671"/>
+                <id value="7b79abbe-1f21-47d1-a5ff-df921c5e6815"/> 
                 <meta>
                     <versionId value="1"/>
                     <lastUpdated value="2020-04-12T18:01:10+00:00"/>


### PR DESCRIPTION
The API examples for the Communication calls had odd IDs like "12345" or "123450". This pull request changes that and replaces them with UUIDs.

It is, however, important to remember that the IDs are just strings.