### PR TITLE
Update Validate Examples Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  REFERENZVALIDATOR_VERSION: 2.0.2
+  REFERENZVALIDATOR_VERSION: 2.5.0
   PATH_TO_EXAMPLES: './temp_folder/'
   FHIR_VERSION: "4.0"
   INPUT_JAVA_VALIDATION_OPTIONS: "-tx http://tx.fhir.org -debug -allow-example-urls true"


### PR DESCRIPTION
Update the Validate Examples GitHub action to make use of the Reference Validator 2.5.0 instead of 2.0.2