### PR TITLE
Update the Validate Examples GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  REFERENZVALIDATOR_VERSION: 2.0.2
+  REFERENZVALIDATOR_VERSION: 2.5.0
   PATH_TO_EXAMPLES: './temp_folder/'
   FHIR_VERSION: "4.0"
   INPUT_JAVA_VALIDATION_OPTIONS: "-tx http://tx.fhir.org -debug -allow-example-urls true"
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -43,7 +43,7 @@ jobs:
       
       # Install Java runtime (only needed if you want to run the offical HL7 Java validator)
       - name: Setup Java JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'


### PR DESCRIPTION
Update the Validate Examples GitHub action to make use of the Reference Validator 2.5.0 instead of 2.0.2
Also updated the checkout, setup-node and setup-java actions to the latest major versions