### PR TITLE
Remove additional text from the examples

### DIFF
--- a/API-Examples/2024-11-01/authentisieren/02_response_ReadCardCertificate.xml
+++ b/API-Examples/2024-11-01/authentisieren/02_response_ReadCardCertificate.xml
@@ -1,6 +1,3 @@
-HTTP/1.1 200 OK
-Content-Type: text/xml;charset=utf-8
-
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
         <ns3:ReadCardCertificateResponse xmlns="http://ws.gematik.de/conn/ConnectorCommon/v5.0"

--- a/API-Examples/2024-11-01/authentisieren/07_response_InnerVau.json
+++ b/API-Examples/2024-11-01/authentisieren/07_response_InnerVau.json
@@ -1,7 +1,3 @@
-1 b69f01734f34376ddcdbdbe9af18a06f HTTP/1.1 200 OK
-Content-Type: application/fhir+json;charset=utf-8
-Content-Location: https://erp.zentral.erp.splitdns.ti-dienste.de/Bundle/f5ba6eaf-9052-42f6-ac4e-fadceed7293b
-
 {
   "resourceType": "Bundle",
   "id": "f5ba6eaf-9052-42f6-ac4e-fadceed7293b",

--- a/API-Examples/2024-11-01/erp_abrufen/05_response_VerifySignatureTask.xml
+++ b/API-Examples/2024-11-01/erp_abrufen/05_response_VerifySignatureTask.xml
@@ -1,4 +1,3 @@
-
 <?xml version='1.0' encoding='UTF-8'?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>

--- a/API-Examples/2024-11-01/erp_bereitstellen/04_response_SignDocument.xml
+++ b/API-Examples/2024-11-01/erp_bereitstellen/04_response_SignDocument.xml
@@ -1,6 +1,3 @@
-HTTP/1.1 200 OK
-Content-Type: text/xml;charset=utf-8
-
 <SOAP-ENV:Envelope
     xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
     <SOAP-ENV:Header/>


### PR DESCRIPTION
Certain examples still contained additional information at the beginning of the files which caused the files to be invalid XML or JSON. 

This pull request removes them