### PR TITLE
Fix the examples using the medication-total-quantity-formulation extension

### DIFF
--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Communication-8ca3c379-ac86-470f-bc12-178c9008f5c9.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Communication-8ca3c379-ac86-470f-bc12-178c9008f5c9.xml
@@ -40,7 +40,7 @@
       <amount>
         <numerator>
           <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-            <valueString value="20 St." />
+            <valueString value="20" />
           </extension>
           <value value="20" />
           <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-Medication-Rezeptur-FD.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-Medication-Rezeptur-FD.xml
@@ -83,7 +83,7 @@
   <amount>
     <numerator>
       <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-        <valueString value="100 ml" />
+        <valueString value="100" />
       </extension>
       <value value="20" />
       <unit value="ml" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-Medication-Rezeptur.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-Medication-Rezeptur.xml
@@ -84,7 +84,7 @@
   <amount>
     <numerator>
       <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-        <valueString value="100 ml" />
+        <valueString value="100" />
       </extension>
       <value value="20" />
       <unit value="ml" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-SumatripanMedication.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Medication-SumatripanMedication.xml
@@ -31,7 +31,7 @@
   <amount>
     <numerator>
       <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-        <valueString value="20 St." />
+        <valueString value="20" />
       </extension>
       <value value="20" />
       <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseInputParameters.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseInputParameters.xml
@@ -76,7 +76,7 @@
           <amount>
             <numerator>
               <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                <valueString value="20 St." />
+                <valueString value="20" />
               </extension>
               <value value="20" />
               <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseInputParametersMultipleMedicationDispenses.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseInputParametersMultipleMedicationDispenses.xml
@@ -76,7 +76,7 @@
           <amount>
             <numerator>
               <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                <valueString value="20 St." />
+                <valueString value="20" />
               </extension>
               <value value="20" />
               <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseOutputParametersSuccess.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleDispenseOutputParametersSuccess.xml
@@ -76,7 +76,7 @@
           <amount>
             <numerator>
               <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                <valueString value="20 St." />
+                <valueString value="20" />
               </extension>
               <value value="20" />
               <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParameters.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParameters.xml
@@ -76,7 +76,7 @@
           <amount>
             <numerator>
               <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                <valueString value="20 St." />
+                <valueString value="20" />
               </extension>
               <value value="20" />
               <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParametersMultipleMedicationDispenses.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParametersMultipleMedicationDispenses.xml
@@ -86,7 +86,7 @@
                         <numerator>
                             <extension
                                 url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                                <valueString value="20 St." />
+                                <valueString value="20" />
                             </extension>
                             <value value="20" />
                             <unit value="St" />

--- a/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParametersRezeptur.xml
+++ b/Standalone-Examples/E-Rezept-Workflow_gematik/1.4.0/Parameters-ExampleOperationCloseInputParametersRezeptur.xml
@@ -129,7 +129,7 @@
           <amount>
             <numerator>
               <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension">
-                <valueString value="100 ml" />
+                <valueString value="100" />
               </extension>
               <value value="20" />
               <unit value="ml" />


### PR DESCRIPTION
This pull request fixes the examples using the medication-total-quantity-formulation extension that have the units in the valueString of the extension. This is done by removing the units