### PR TITLE
Update the erp_abrufen_egk example from erxTask to GEM_ERP_PR_Task

### DIFF
--- a/API-Examples/2024-11-01/erp_abrufen_egk/05_Response_Task.xml
+++ b/API-Examples/2024-11-01/erp_abrufen_egk/05_Response_Task.xml
@@ -1,116 +1,116 @@
 <Bundle xmlns="http://hl7.org/fhir">
-   <id value="61d2400c-a7b5-4c1e-a4dd-ed4a3c9fe5e9"/>
-   <type value="searchset"/>
-   <timestamp value="2023-05-16T07:03:18.844+00:00"/>
-   <total value="2"/>
-   <entry>
-      <fullUrl value="https://erp-dev.zentral.erp.splitdns.ti-dienste.de/Task/160.000.036.967.704.52"/>
-      <resource>
-         <Task xmlns="http://hl7.org/fhir">
-            <id value="160.000.036.967.704.52"/>
-            <meta>
-               <profile value="https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"/>
-            </meta>
-            <extension url="https://gematik.de/fhir/StructureDefinition/PrescriptionType">
-               <valueCoding>
-                  <system value="https://gematik.de/fhir/CodeSystem/Flowtype"/>
-                  <code value="160"/>
-                  <display value="Muster 16 (Apothekenpflichtige Arzneimittel)"/>
-               </valueCoding>
-            </extension>
-            <extension url="https://gematik.de/fhir/StructureDefinition/ExpiryDate">
-               <valueDate value="2023-07-11"/>
-            </extension>
-            <extension url="https://gematik.de/fhir/StructureDefinition/AcceptDate">
-               <valueDate value="2023-05-09"/>
-            </extension>
-            <identifier>
-               <use value="official"/>
-               <system value="https://gematik.de/fhir/NamingSystem/PrescriptionID"/>
-               <value value="160.000.036.967.704.52"/>
-            </identifier>
-            <identifier>
-               <use value="official"/>
-               <system value="https://gematik.de/fhir/NamingSystem/AccessCode"/>
-               <value value="eb6002c60dffdfb742002bf44f9f72326de3dddfe2271ab64a21a6cb0f168bbf"/>
-            </identifier>
-            <status value="ready"/>
-            <intent value="order"/>
-            <for>
-               <identifier>
-                  <system value="http://fhir.de/NamingSystem/gkv/kvid-10"/>
-                  <value value="T046142499"/>
-               </identifier>
-            </for>
-            <authoredOn value="2023-04-11T09:10:16.519+00:00"/>
-            <lastModified value="2023-04-11T09:10:18.926+00:00"/>
-            <performerType>
-               <coding>
-                  <system value="urn:ietf:rfc:3986"/>
-                  <code value="urn:oid:1.2.276.0.76.4.54"/>
-                  <display value="Öffentliche Apotheke"/>
-               </coding>
-               <text value="Öffentliche Apotheke"/>
-            </performerType>
-         </Task>
-      </resource>
-      <search>
-         <mode value="match"/>
-      </search>
-   </entry>
-   <entry>
-      <fullUrl value="https://erp-dev.zentral.erp.splitdns.ti-dienste.de/Task/160.000.036.968.008.13"/>
-      <resource>
-         <Task xmlns="http://hl7.org/fhir">
-            <id value="160.000.036.968.008.13"/>
-            <meta>
-               <profile value="https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"/>
-            </meta>
-            <extension url="https://gematik.de/fhir/StructureDefinition/PrescriptionType">
-               <valueCoding>
-                  <system value="https://gematik.de/fhir/CodeSystem/Flowtype"/>
-                  <code value="160"/>
-                  <display value="Muster 16 (Apothekenpflichtige Arzneimittel)"/>
-               </valueCoding>
-            </extension>
-            <extension url="https://gematik.de/fhir/StructureDefinition/ExpiryDate">
-               <valueDate value="2023-07-12"/>
-            </extension>
-            <extension url="https://gematik.de/fhir/StructureDefinition/AcceptDate">
-               <valueDate value="2023-05-10"/>
-            </extension>
-            <identifier>
-               <use value="official"/>
-               <system value="https://gematik.de/fhir/NamingSystem/PrescriptionID"/>
-               <value value="160.000.036.968.008.13"/>
-            </identifier>
-            <identifier>
-               <use value="official"/>
-               <system value="https://gematik.de/fhir/NamingSystem/AccessCode"/>
-               <value value="16ba6a9a4440fbf815351fe7080572ab3ae9acbba404efa259074a56dac21725"/>
-            </identifier>
-            <status value="ready"/>
-            <intent value="order"/>
-            <for>
-               <identifier>
-                  <system value="http://fhir.de/NamingSystem/gkv/kvid-10"/>
-                  <value value="T046142499"/>
-               </identifier>
-            </for>
-            <authoredOn value="2023-04-12T06:42:30.913+00:00"/>
-            <lastModified value="2023-04-12T06:42:33.275+00:00"/>
-            <performerType>
-               <coding>
-                  <system value="urn:ietf:rfc:3986"/>
-                  <code value="urn:oid:1.2.276.0.76.4.54"/>
-                  <display value="Öffentliche Apotheke"/>
-               </coding>
-               <text value="Öffentliche Apotheke"/>
-            </performerType>
-         </Task>
-      </resource>
-      <search>
-         <mode value="match"/>
-      </search>
-   </entry>
+	<id value="erp-abrufen-egk-05-Response-Task" />
+	<type value="searchset" />
+	<timestamp value="2023-05-16T07:03:18.844+00:00" />
+	<total value="2" />
+	<entry>
+		<fullUrl value="https://erp-dev.zentral.erp.splitdns.ti-dienste.de/Task/160.000.036.967.704.52" />
+		<resource>
+			<Task>
+				<id value="160.000.036.967.704.52" />
+				<meta>
+					<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3" />
+				</meta>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
+					<valueCoding>
+						<system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType" />
+						<code value="160" />
+						<display value="Muster 16 (Apothekenpflichtige Arzneimittel)" />
+					</valueCoding>
+				</extension>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate">
+					<valueDate value="2023-07-11" />
+				</extension>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate">
+					<valueDate value="2023-05-09" />
+				</extension>
+				<identifier>
+					<use value="official" />
+					<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+					<value value="160.000.036.967.704.52" />
+				</identifier>
+				<identifier>
+					<use value="official" />
+					<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode" />
+					<value value="eb6002c60dffdfb742002bf44f9f72326de3dddfe2271ab64a21a6cb0f168bbf" />
+				</identifier>
+				<status value="ready" />
+				<intent value="order" />
+				<for>
+					<identifier>
+						<system value="http://fhir.de/sid/gkv/kvid-10" />
+						<value value="T046142499" />
+					</identifier>
+				</for>
+				<authoredOn value="2023-04-11T09:10:16.519+00:00" />
+				<lastModified value="2023-04-11T09:10:18.926+00:00" />
+				<performerType>
+					<coding>
+						<system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType" />
+						<code value="urn:oid:1.2.276.0.76.4.54" />
+						<display value="Öffentliche Apotheke" />
+					</coding>
+					<text value="Öffentliche Apotheke" />
+				</performerType>
+			</Task>
+		</resource>
+		<search>
+			<mode value="match" />
+		</search>
+	</entry>
+	<entry>
+		<fullUrl value="https://erp-dev.zentral.erp.splitdns.ti-dienste.de/Task/160.000.036.968.008.13" />
+		<resource>
+			<Task>
+				<id value="160.000.036.968.008.13" />
+				<meta>
+					<profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3" />
+				</meta>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
+					<valueCoding>
+						<system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType" />
+						<code value="160" />
+						<display value="Muster 16 (Apothekenpflichtige Arzneimittel)" />
+					</valueCoding>
+				</extension>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate">
+					<valueDate value="2023-07-12" />
+				</extension>
+				<extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate">
+					<valueDate value="2023-05-10" />
+				</extension>
+				<identifier>
+					<use value="official" />
+					<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+					<value value="160.000.036.968.008.13" />
+				</identifier>
+				<identifier>
+					<use value="official" />
+					<system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode" />
+					<value value="16ba6a9a4440fbf815351fe7080572ab3ae9acbba404efa259074a56dac21725" />
+				</identifier>
+				<status value="ready" />
+				<intent value="order" />
+				<for>
+					<identifier>
+						<system value="http://fhir.de/sid/gkv/kvid-10" />
+						<value value="T046142499" />
+					</identifier>
+				</for>
+				<authoredOn value="2023-04-12T06:42:30.913+00:00" />
+				<lastModified value="2023-04-12T06:42:33.275+00:00" />
+				<performerType>
+					<coding>
+						<system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType" />
+						<code value="urn:oid:1.2.276.0.76.4.54" />
+						<display value="Öffentliche Apotheke" />
+					</coding>
+					<text value="Öffentliche Apotheke" />
+				</performerType>
+			</Task>
+		</resource>
+		<search>
+			<mode value="match" />
+		</search>
+	</entry>
 </Bundle>

--- a/API-Examples/FSH-Files/fsh-generated/resources/Bundle-erp-abrufen-egk-05-Response-Task.json
+++ b/API-Examples/FSH-Files/fsh-generated/resources/Bundle-erp-abrufen-egk-05-Response-Task.json
@@ -12,42 +12,42 @@
         "id": "160.000.036.967.704.52",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
           ]
         },
         "extension": [
           {
             "valueCoding": {
-              "system": "https://gematik.de/fhir/CodeSystem/Flowtype",
+              "system": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType",
               "code": "160",
               "display": "Muster 16 (Apothekenpflichtige Arzneimittel)"
             },
-            "url": "https://gematik.de/fhir/StructureDefinition/PrescriptionType"
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
           },
           {
-            "url": "https://gematik.de/fhir/StructureDefinition/ExpiryDate",
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate",
             "valueDate": "2023-07-11"
           },
           {
-            "url": "https://gematik.de/fhir/StructureDefinition/AcceptDate",
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate",
             "valueDate": "2023-05-09"
           }
         ],
         "identifier": [
           {
             "use": "official",
-            "system": "https://gematik.de/fhir/NamingSystem/PrescriptionID",
+            "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
             "value": "160.000.036.967.704.52"
           },
           {
             "use": "official",
-            "system": "https://gematik.de/fhir/NamingSystem/AccessCode",
+            "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode",
             "value": "eb6002c60dffdfb742002bf44f9f72326de3dddfe2271ab64a21a6cb0f168bbf"
           }
         ],
         "for": {
           "identifier": {
-            "system": "http://fhir.de/NamingSystem/gkv/kvid-10",
+            "system": "http://fhir.de/sid/gkv/kvid-10",
             "value": "T046142499"
           }
         },
@@ -55,7 +55,7 @@
           {
             "coding": [
               {
-                "system": "urn:ietf:rfc:3986",
+                "system": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType",
                 "code": "urn:oid:1.2.276.0.76.4.54",
                 "display": "Öffentliche Apotheke"
               }
@@ -79,42 +79,42 @@
         "id": "160.000.036.968.008.13",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
           ]
         },
         "extension": [
           {
             "valueCoding": {
-              "system": "https://gematik.de/fhir/CodeSystem/Flowtype",
+              "system": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType",
               "code": "160",
               "display": "Muster 16 (Apothekenpflichtige Arzneimittel)"
             },
-            "url": "https://gematik.de/fhir/StructureDefinition/PrescriptionType"
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
           },
           {
-            "url": "https://gematik.de/fhir/StructureDefinition/ExpiryDate",
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate",
             "valueDate": "2023-07-12"
           },
           {
-            "url": "https://gematik.de/fhir/StructureDefinition/AcceptDate",
+            "url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate",
             "valueDate": "2023-05-10"
           }
         ],
         "identifier": [
           {
             "use": "official",
-            "system": "https://gematik.de/fhir/NamingSystem/PrescriptionID",
+            "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
             "value": "160.000.036.968.008.13"
           },
           {
             "use": "official",
-            "system": "https://gematik.de/fhir/NamingSystem/AccessCode",
+            "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode",
             "value": "16ba6a9a4440fbf815351fe7080572ab3ae9acbba404efa259074a56dac21725"
           }
         ],
         "for": {
           "identifier": {
-            "system": "http://fhir.de/NamingSystem/gkv/kvid-10",
+            "system": "http://fhir.de/sid/gkv/kvid-10",
             "value": "T046142499"
           }
         },
@@ -122,7 +122,7 @@
           {
             "coding": [
               {
-                "system": "urn:ietf:rfc:3986",
+                "system": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType",
                 "code": "urn:oid:1.2.276.0.76.4.54",
                 "display": "Öffentliche Apotheke"
               }

--- a/API-Examples/FSH-Files/input/fsh/examples/erp_abrufen_egk/05_Response_Task.fsh
+++ b/API-Examples/FSH-Files/input/fsh/examples/erp_abrufen_egk/05_Response_Task.fsh
@@ -14,29 +14,29 @@ Usage: #example
 Instance: 160.000.036.967.704.52
 InstanceOf: Task
 Usage: #inline
-* meta.profile = "https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"
-* extension[0].url = "https://gematik.de/fhir/StructureDefinition/PrescriptionType"
-* extension[=].valueCoding.system = $Flowtype
+* meta.profile = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
+* extension[0].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[=].valueCoding.system = $GEM_ERP_CS_FlowType
 * extension[=].valueCoding.code = #160
 * extension[=].valueCoding.display = "Muster 16 (Apothekenpflichtige Arzneimittel)"
 //* extension[=].valueCoding = $Flowtype#160 "Muster 16 (Apothekenpflichtige Arzneimittel)"
-* extension[+].url = "https://gematik.de/fhir/StructureDefinition/ExpiryDate"
+* extension[+].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate"
 * extension[=].valueDate = "2023-07-11"
-* extension[+].url = "https://gematik.de/fhir/StructureDefinition/AcceptDate"
+* extension[+].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate"
 * extension[=].valueDate = "2023-05-09"
 * identifier[0].use = #official
-* identifier[=].system = "https://gematik.de/fhir/NamingSystem/PrescriptionID"
+* identifier[=].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
 * identifier[=].value = "160.000.036.967.704.52"
 * identifier[+].use = #official
-* identifier[=].system = "https://gematik.de/fhir/NamingSystem/AccessCode"
+* identifier[=].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode"
 * identifier[=].value = "eb6002c60dffdfb742002bf44f9f72326de3dddfe2271ab64a21a6cb0f168bbf"
 * status = #ready
 * intent = #order
-* for.identifier.system = "http://fhir.de/NamingSystem/gkv/kvid-10"
+* for.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
 * for.identifier.value = "T046142499"
 * authoredOn = "2023-04-11T09:10:16.519+00:00"
 * lastModified = "2023-04-11T09:10:18.926+00:00"
-* performerType.coding.system = "urn:ietf:rfc:3986"
+* performerType.coding.system = "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType"
 * performerType.coding.code = #urn:oid:1.2.276.0.76.4.54
 * performerType.coding.display = "Öffentliche Apotheke"
 //* performerType = urn:ietf:rfc:3986#urn:oid:1.2.276.0.76.4.54 "Öffentliche Apotheke"
@@ -45,29 +45,29 @@ Usage: #inline
 Instance: 160.000.036.968.008.13
 InstanceOf: Task
 Usage: #inline
-* meta.profile = "https://gematik.de/fhir/StructureDefinition/ErxTask|1.1.1"
-* extension[0].url = "https://gematik.de/fhir/StructureDefinition/PrescriptionType"
-* extension[=].valueCoding.system = $Flowtype
+* meta.profile = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
+* extension[0].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"
+* extension[=].valueCoding.system = $GEM_ERP_CS_FlowType
 * extension[=].valueCoding.code = #160
 * extension[=].valueCoding.display = "Muster 16 (Apothekenpflichtige Arzneimittel)"
 //* extension[=].valueCoding = $Flowtype#160 "Muster 16 (Apothekenpflichtige Arzneimittel)"
-* extension[+].url = "https://gematik.de/fhir/StructureDefinition/ExpiryDate"
+* extension[+].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate"
 * extension[=].valueDate = "2023-07-12"
-* extension[+].url = "https://gematik.de/fhir/StructureDefinition/AcceptDate"
+* extension[+].url = "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate"
 * extension[=].valueDate = "2023-05-10"
 * identifier[0].use = #official
-* identifier[=].system = "https://gematik.de/fhir/NamingSystem/PrescriptionID"
+* identifier[=].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
 * identifier[=].value = "160.000.036.968.008.13"
 * identifier[+].use = #official
-* identifier[=].system = "https://gematik.de/fhir/NamingSystem/AccessCode"
+* identifier[=].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_AccessCode"
 * identifier[=].value = "16ba6a9a4440fbf815351fe7080572ab3ae9acbba404efa259074a56dac21725"
 * status = #ready
 * intent = #order
-* for.identifier.system = "http://fhir.de/NamingSystem/gkv/kvid-10"
+* for.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
 * for.identifier.value = "T046142499"
 * authoredOn = "2023-04-12T06:42:30.913+00:00"
 * lastModified = "2023-04-12T06:42:33.275+00:00"
-* performerType.coding.system = "urn:ietf:rfc:3986"
+* performerType.coding.system = "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType"
 * performerType.coding.code = #urn:oid:1.2.276.0.76.4.54
 * performerType.coding.display = "Öffentliche Apotheke"
 //* performerType = urn:ietf:rfc:3986#urn:oid:1.2.276.0.76.4.54 "Öffentliche Apotheke"


### PR DESCRIPTION
Workflow Profile 1.1.1 has been deprecated and is no longer valid. 

This pull request updates the examples still using that to use a newer valid profile. The fsh files have also been updated.