### PR TITLE
add xml declaration to communication samples

### DIFF
--- a/API-Examples/2025-01-15/erp_communication/03_request_PostPharmacyToPatient.xml
+++ b/API-Examples/2025-01-15/erp_communication/03_request_PostPharmacyToPatient.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <Communication xmlns="http://hl7.org/fhir">
     <id value="erp-communication-03-request-PostPharmacyToPatient"/>
     <meta>

--- a/API-Examples/2025-01-15/erp_communication/04_response_PostPharmacyToPatient.xml
+++ b/API-Examples/2025-01-15/erp_communication/04_response_PostPharmacyToPatient.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <Communication xmlns="http://hl7.org/fhir">
     <id value="erp-communication-04-response-PostPharmacyToPatient"/>
     <meta>

--- a/API-Examples/2025-01-15/erp_communication/08_response_GetAllMessages.xml
+++ b/API-Examples/2025-01-15/erp_communication/08_response_GetAllMessages.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <Bundle xmlns="http://hl7.org/fhir">
     <id value="erp-communication-08-response-GetAllMessages"/>
     <type value="searchset"/>


### PR DESCRIPTION
The xml declaration for the communication samples for version 1.4 are missing. On purpose? If not, you should consider adding the encoding as well:
```
<?xml version="1.0" encoding="utf-8"?>
```