### PR TITLE
Update the reference validator version being used in the main GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  REFERENZVALIDATOR_VERSION: 2.8.0
+  REFERENZVALIDATOR_VERSION: 2.9.0
   PATH_TO_EXAMPLES: './temp_folder/'
   FHIR_VERSION: "4.0"
 


### PR DESCRIPTION
Update the reference validator version being used in the main GitHub action from 2.8.0 to 2.9.0