### PR TITLE
upgrade the Referenzvalidator to version 2.10.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  REFERENZVALIDATOR_VERSION: 2.9.0
+  REFERENZVALIDATOR_VERSION: 2.10.0
   PATH_TO_EXAMPLES: './temp_folder/'
   FHIR_VERSION: "4.0"
 


### PR DESCRIPTION
This pull request upgrades the Referenzvalidator used in the specific GitHub Action to version 2.10.0