### PR TITLE
Add copyright header for OSPO compliance

### DIFF
--- a/api-examples/fsh/input/fsh/examples/erp_alternative_zuweisung/06_example_encryption.java
+++ b/api-examples/fsh/input/fsh/examples/erp_alternative_zuweisung/06_example_encryption.java
@@ -1,3 +1,23 @@
+/*
+Copyright (Change Date see Readme), gematik GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*******
+
+For additional notes and disclaimer from gematik and in case of changes
+by gematik, find details in the "Readme" file.
+*/
 public class example_encryption {
     val info = ASN1EncodableVector().apply
     {

--- a/api-examples/generated-examples/erp_alternative_zuweisung/06_example_encryption.java
+++ b/api-examples/generated-examples/erp_alternative_zuweisung/06_example_encryption.java
@@ -1,3 +1,23 @@
+/*
+Copyright (Change Date see Readme), gematik GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*******
+
+For additional notes and disclaimer from gematik and in case of changes
+by gematik, find details in the "Readme" file.
+*/
 public class example_encryption {
     val info = ASN1EncodableVector().apply
     {


### PR DESCRIPTION
Include a copyright header in the file to ensure compliance with OSPO requirements.