### PR TITLE
Add notification payload examples for ERP push notifications

### DIFF
--- a/api-examples/fsh/input/fsh/examples/erp_push_notifications/01_notification_payload.json
+++ b/api-examples/fsh/input/fsh/examples/erp_push_notifications/01_notification_payload.json
@@ -1,0 +1,8 @@
+{
+  "ChannelId": "erp.communication.new",
+  "Identifier": "160.000.000.000.123.76",
+  "IdentifierType": "TaskId",
+  "Product": "Sumatriptan-1a Pharma 100 mg Tabletten",
+  "ActorName": "Meine Apotheke",
+  "Message": "Wir möchten Sie informieren, dass Ihre bestellten Medikamente zur Abholung bereitstehen."
+}

--- a/api-examples/generated-examples/erp_push_notifications/01_notification_payload.json
+++ b/api-examples/generated-examples/erp_push_notifications/01_notification_payload.json
@@ -1,0 +1,8 @@
+{
+  "ChannelId": "erp.communication.new",
+  "Identifier": "160.000.000.000.123.76",
+  "IdentifierType": "TaskId",
+  "Product": "Sumatriptan-1a Pharma 100 mg Tabletten",
+  "ActorName": "Meine Apotheke",
+  "Message": "Wir möchten Sie informieren, dass Ihre bestellten Medikamente zur Abholung bereitstehen."
+}


### PR DESCRIPTION
Include examples of notification payloads for ERP push notifications to facilitate integration and testing.